### PR TITLE
Add Option To Keep Dialog Visible On Button Press

### DIFF
--- a/dialogsheet/src/main/java/com/marcoscg/dialogsheet/DialogSheet.java
+++ b/dialogsheet/src/main/java/com/marcoscg/dialogsheet/DialogSheet.java
@@ -155,7 +155,7 @@ public class DialogSheet {
         return this;
     }
 
-    public DialogSheet setPositiveButton(CharSequence text, final OnPositiveClickListener onPositiveClickListener) {
+    public DialogSheet setPositiveButton(CharSequence text, final boolean shouldDismiss, final OnPositiveClickListener onPositiveClickListener) {
         if (text == null)
             positiveButton.setVisibility(View.GONE);
         else {
@@ -164,7 +164,8 @@ public class DialogSheet {
             positiveButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    bottomSheetDialog.dismiss();
+                    if (shouldDismiss)
+                        bottomSheetDialog.dismiss();
                     if (onPositiveClickListener!=null)
                         onPositiveClickListener.onClick(view);
                 }
@@ -174,12 +175,22 @@ public class DialogSheet {
         return this;
     }
 
-    public DialogSheet setPositiveButton(@StringRes int textRes, OnPositiveClickListener onPositiveClickListener) {
-        setPositiveButton(context.getResources().getString(textRes), onPositiveClickListener);
+    public DialogSheet setPositiveButton(CharSequence text, final OnPositiveClickListener onPositiveClickListener) {
+        setPositiveButton(text, true, onPositiveClickListener);
         return this;
     }
 
-    public DialogSheet setNegativeButton(CharSequence text, final OnNegativeClickListener onNegativeClickListener) {
+    public DialogSheet setPositiveButton(@StringRes int textRes, OnPositiveClickListener onPositiveClickListener) {
+        setPositiveButton(context.getResources().getString(textRes), true, onPositiveClickListener);
+        return this;
+    }
+
+    public DialogSheet setPositiveButton(@StringRes int textRes, boolean shouldDismiss, OnPositiveClickListener onPositiveClickListener) {
+        setPositiveButton(context.getResources().getString(textRes), shouldDismiss, onPositiveClickListener);
+        return this;
+    }
+
+    public DialogSheet setNegativeButton(CharSequence text, final boolean shoudDismiss, final OnNegativeClickListener onNegativeClickListener) {
         if (text == null)
             negativeButton.setVisibility(View.GONE);
         else {
@@ -188,7 +199,8 @@ public class DialogSheet {
             negativeButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    bottomSheetDialog.dismiss();
+                    if (shoudDismiss)
+                        bottomSheetDialog.dismiss();
                     if (onNegativeClickListener!=null)
                         onNegativeClickListener.onClick(view);
                 }
@@ -198,8 +210,18 @@ public class DialogSheet {
         return this;
     }
 
+    public DialogSheet setNegativeButton(CharSequence text, final OnNegativeClickListener onNegativeClickListener) {
+        setNegativeButton(text, true, onNegativeClickListener);
+        return this;
+    }
+
     public DialogSheet setNegativeButton(@StringRes int textRes, OnNegativeClickListener onNegativeClickListener) {
-        setNegativeButton(context.getResources().getString(textRes), onNegativeClickListener);
+        setNegativeButton(context.getResources().getString(textRes), true, onNegativeClickListener);
+        return this;
+    }
+
+    public DialogSheet setNegativeButton(@StringRes int textRes, boolean shoudDismiss, OnNegativeClickListener onNegativeClickListener) {
+        setNegativeButton(context.getResources().getString(textRes), shoudDismiss, onNegativeClickListener);
         return this;
     }
 


### PR DESCRIPTION
 Example: If the dialog is used with a custom view for form input, this would allow form validation to occur and keep the dialog visible if an error occurred